### PR TITLE
Fix an error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You need to install [wasi-vfs 0.5.0](https://github.com/kateinoigakukun/wasi-vfs
 
 ```console
 $ bundle install
-$ rake setup
+$ rake head-wasm32-unknown-wasi-full-c@e
 $ ./exe/ruby-compute-runtime ./examples/demo.rb -o tmp/sample.wasm
 
 $ # Try on local


### PR DESCRIPTION
With the latest version, `$rake setup` gives me the following error;

```
$ rake setup
rake aborted!
Don't know how to build task 'setup' (See the list of available tasks with `rake --tasks`)
/usr/local/bundle/gems/rake-13.1.0/exe/rake:27:in `<top (required)>'
(See full trace by running task with --trace)
```

It looks like :setup method is removed now. Instead, `$rake head-wasm32-unknown-wasi-full-c@e` worked for me.