### PR TITLE
Add support for hostcalls to proxy request to backend server

### DIFF
--- a/examples/proxy_request.rb
+++ b/examples/proxy_request.rb
@@ -1,0 +1,17 @@
+# Example:
+# $ ./exe/ruby-compute-runtime ./examples/proxy_request.rb -o tmp/sample.wasm
+# $ viceroy ./tmp/sample.wasm
+
+require "compute_runtime"
+
+req = ComputeRuntime::Request.new
+resp = ComputeRuntime::Response.new
+begin
+    req.method = "GET"
+    req.uri = "https://www.ruby-lang.org/en/"
+    result = req.send ComputeRuntime::Body.new.handle, "origin_0"
+    resp.send_downstream ComputeRuntime::Body.new(result[1])
+rescue Exception => e
+    body.write "#{e}"
+    resp.send_downstream body
+end

--- a/examples/proxy_request.rb
+++ b/examples/proxy_request.rb
@@ -1,6 +1,14 @@
 # Example:
 # $ ./exe/ruby-compute-runtime ./examples/proxy_request.rb -o tmp/sample.wasm
-# $ viceroy ./tmp/sample.wasm
+# $ viceroy -v -C ./fastly.toml ./tmp/sample.wasm
+#
+# [IMPORTANT] Make sure your fastly.toml file has necessary configuration like below;
+# ```
+# [local_server]
+#   [local_server.backends]
+#     [local_server.backends.origin_0]
+#       url = "https://www.ruby-lang.org"
+# ```
 
 require "compute_runtime"
 

--- a/ext/compute_runtime/compute_at_edge_abi.h
+++ b/ext/compute_runtime/compute_at_edge_abi.h
@@ -69,17 +69,17 @@ fastly_status_t fastly_log_write(log_endpoint_handle_t endpoint_handle,
 
 // Module fastly_http_req
 WASM_IMPORT("fastly_http_req", "body_downstream_get")
-fastly_status_t fastly_req_body_downstream_get(request_handle_t *req_handle_out,
+fastly_status_t fastly_http_req_body_downstream_get(request_handle_t *req_handle_out,
                                                body_handle_t *body_handle_out);
 
 WASM_IMPORT("fastly_http_req", "cache_override_set")
-fastly_status_t fastly_req_cache_override_set(request_handle_t req_handle,
+fastly_status_t fastly_http_req_cache_override_set(request_handle_t req_handle,
                                               int tag, uint32_t ttl,
                                               uint32_t stale_while_revalidate);
 
 WASM_IMPORT("fastly_http_req", "cache_override_v2_set")
 fastly_status_t
-fastly_req_cache_override_v2_set(request_handle_t req_handle, int tag,
+fastly_http_req_cache_override_v2_set(request_handle_t req_handle, int tag,
                                  uint32_t ttl, uint32_t stale_while_revalidate,
                                  const char *surrogate_key,
                                  size_t surrogate_key_len);
@@ -88,81 +88,81 @@ WASM_IMPORT("fastly_http_req", "downstream_client_ip_addr")
 fastly_status_t fastly_http_req_downstream_client_ip_addr(uint8_t *octets,
                                                           size_t *nwritten);
 WASM_IMPORT("fastly_http_req", "new")
-fastly_status_t fastly_req_new(request_handle_t *req_handle_out);
+fastly_status_t fastly_http_req_new(request_handle_t *req_handle_out);
 
 WASM_IMPORT("fastly_http_req", "header_names_get")
-fastly_status_t fastly_req_header_names_get(request_handle_t req_handle,
+fastly_status_t fastly_http_req_header_names_get(request_handle_t req_handle,
                                             char *buf, size_t buf_len,
                                             uint32_t cursor,
                                             int64_t *ending_cursor,
                                             size_t *nwritten);
 
 WASM_IMPORT("fastly_http_req", "original_header_names_get")
-fastly_status_t fastly_req_original_header_names_get(char *buf, size_t buf_len,
+fastly_status_t fastly_http_req_original_header_names_get(char *buf, size_t buf_len,
                                                      uint32_t cursor,
                                                      int64_t *ending_cursor,
                                                      size_t *nwritten);
 
 WASM_IMPORT("fastly_http_req", "original_header_count")
-fastly_status_t fastly_req_original_header_count(uint32_t *count);
+fastly_status_t fastly_http_req_original_header_count(uint32_t *count);
 
 WASM_IMPORT("fastly_http_req", "header_value_get")
-fastly_status_t fastly_req_header_value_get(request_handle_t req_handle,
+fastly_status_t fastly_http_req_header_value_get(request_handle_t req_handle,
                                             const char *name, size_t name_len,
                                             char *value, size_t value_max_len,
                                             size_t *nwritten);
 
 WASM_IMPORT("fastly_http_req", "header_values_get")
-fastly_status_t fastly_req_header_values_get(
+fastly_status_t fastly_http_req_header_values_get(
     request_handle_t req_handle, const char *name, size_t name_len, char *buf,
     size_t buf_len, uint32_t cursor, int64_t *ending_cursor, size_t *nwritten);
 
 WASM_IMPORT("fastly_http_req", "header_values_set")
-fastly_status_t fastly_req_header_values_set(request_handle_t req_handle,
+fastly_status_t fastly_http_req_header_values_set(request_handle_t req_handle,
                                              const char *name, size_t name_len,
                                              const char *values,
                                              size_t values_len);
 
 WASM_IMPORT("fastly_http_req", "header_insert")
-fastly_status_t fastly_req_header_insert(request_handle_t req_handle,
+fastly_status_t fastly_http_req_header_insert(request_handle_t req_handle,
                                          const char *name, size_t name_len,
                                          const char *value, size_t value_len);
 
 WASM_IMPORT("fastly_http_req", "header_append")
-fastly_status_t fastly_req_header_append(request_handle_t req_handle,
+fastly_status_t fastly_http_req_header_append(request_handle_t req_handle,
                                          const char *name, size_t name_len,
                                          const char *value, size_t value_len);
 
 WASM_IMPORT("fastly_http_req", "header_remove")
-fastly_status_t fastly_req_header_remove(request_handle_t req_handle,
+fastly_status_t fastly_http_req_header_remove(request_handle_t req_handle,
                                          const char *name, size_t name_len);
 
 WASM_IMPORT("fastly_http_req", "method_get")
-fastly_status_t fastly_req_method_get(request_handle_t req_handle, char *method,
+fastly_status_t fastly_http_req_method_get(request_handle_t req_handle, char *method,
                                       size_t method_max_len, size_t *nwritten);
 
 WASM_IMPORT("fastly_http_req", "method_set")
-fastly_status_t fastly_req_method_set(request_handle_t req_handle,
+fastly_status_t fastly_http_req_method_set(request_handle_t req_handle,
                                       const char *method, size_t method_len);
 
 WASM_IMPORT("fastly_http_req", "uri_get")
-fastly_status_t fastly_req_uri_get(request_handle_t req_handle, char *uri,
+fastly_status_t fastly_http_req_uri_get(request_handle_t req_handle, char *uri,
                                    size_t uri_max_len, size_t *nwritten);
 
 WASM_IMPORT("fastly_http_req", "uri_set")
-fastly_status_t fastly_req_uri_set(request_handle_t req_handle, const char *uri,
+fastly_status_t fastly_http_req_uri_set(request_handle_t req_handle, const char *uri,
                                    size_t uri_len);
 
 WASM_IMPORT("fastly_http_req", "version_get")
-fastly_status_t fastly_req_version_get(request_handle_t req_handle,
+fastly_status_t fastly_http_req_version_get(request_handle_t req_handle,
                                        uint32_t *version);
 
 WASM_IMPORT("fastly_http_req", "version_set")
-fastly_status_t fastly_req_version_set(request_handle_t req_handle,
+fastly_status_t fastly_http_req_version_set(request_handle_t req_handle,
                                        uint32_t version);
 
 WASM_IMPORT("fastly_http_req", "send")
-fastly_status_t fastly_req_send(request_handle_t req_handle,
+fastly_status_t fastly_http_req_send(request_handle_t req_handle,
                                 body_handle_t body_handle, const char *backend,
                                 size_t backend_len,
                                 response_handle_t *resp_handle_out,
@@ -170,29 +170,29 @@ fastly_status_t fastly_req_send(request_handle_t req_handle,
 
 WASM_IMPORT("fastly_http_req", "send_async")
 fastly_status_t
-fastly_req_send_async(request_handle_t req_handle, body_handle_t body_handle,
+fastly_http_req_send_async(request_handle_t req_handle, body_handle_t body_handle,
                       const char *backend, size_t backend_len,
                       pending_request_handle_t *pending_req_out);
 
 WASM_IMPORT("fastly_http_req", "send_async_streaming")
-fastly_status_t fastly_req_send_async_streaming(
+fastly_status_t fastly_http_req_send_async_streaming(
     request_handle_t req_handle, body_handle_t body_handle, const char *backend,
     size_t backend_len, pending_request_handle_t *pending_req_out);
 
 WASM_IMPORT("fastly_http_req", "pending_req_poll")
-fastly_status_t fastly_req_pending_req_poll(
+fastly_status_t fastly_http_req_pending_req_poll(
     pending_request_handle_t req_handle, uint32_t *is_done_out,
     response_handle_t *resp_handle_out, body_handle_t *resp_body_handle_out);
 
 WASM_IMPORT("fastly_http_req", "pending_req_wait")
 fastly_status_t
-fastly_req_pending_req_wait(pending_request_handle_t req_handle,
+fastly_http_req_pending_req_wait(pending_request_handle_t req_handle,
                             response_handle_t *resp_handle_out,
                             body_handle_t *resp_body_handle_out);
 
 WASM_IMPORT("fastly_http_req", "pending_req_select")
 fastly_status_t
-fastly_req_pending_req_select(pending_request_handle_t req_handles[],
+fastly_http_req_pending_req_select(pending_request_handle_t req_handles[],
                               size_t req_handles_len, uint32_t *done_idx_out,
                               response_handle_t *resp_handle_out,
                               body_handle_t *resp_body_handle_out);
@@ -269,11 +269,11 @@ fastly_status_t fastly_http_resp_status_set(response_handle_t resp_handle,
 // Module fastly_dictionary
 WASM_IMPORT("fastly_dictionary", "open")
 fastly_status_t
-fastly_http_dictionary_open(const char *name, size_t name_len,
+fastly_dictionary_open(const char *name, size_t name_len,
                             dictionary_handle_t *dict_handle_out);
 
 WASM_IMPORT("fastly_dictionary", "get")
-fastly_status_t fastly_http_dictionary_get(dictionary_handle_t dict_handle,
+fastly_status_t fastly_dictionary_get(dictionary_handle_t dict_handle,
                                            const char *key, size_t key_len,
                                            char *value, size_t value_max_len,
                                            size_t *nwritten);

--- a/lib/compute_runtime.rb
+++ b/lib/compute_runtime.rb
@@ -6,6 +6,30 @@ require_relative "compute_runtime/version"
 module ComputeRuntime
   class Error < StandardError; end
 
+  class Request
+    attr_reader :handle
+    def initialize(handle = nil)
+      @handle = handle || ::ComputeRuntime::ABI.fastly_http_req_new
+    end
+
+    def method=(method)
+      ::ComputeRuntime::ABI.fastly_http_req_method_set(@handle, method)
+    end
+
+    def uri=(uri)
+      ::ComputeRuntime::ABI.fastly_http_req_uri_set(@handle, uri)
+    end
+
+    def send(body, backend)
+      ::ComputeRuntime::ABI.fastly_http_req_send(@handle, body, backend)
+    end
+
+    def self.body_downstream_get
+      #::ComputeRuntime::ABI.fastly_abi_init
+      ::ComputeRuntime::ABI.fastly_http_req_body_downstream_get
+    end
+  end
+
   class Body
     attr_reader :handle
     def initialize(handle = nil)


### PR DESCRIPTION
This commit will add support for the following hostcalls;
- fastly_abi_init
- fastly_http_req_new
- fastly_http_req_method_set
- fastly_http_req_uri_set
- fastly_http_req_send
- fastly_http_req_body_downstream_get

Please refer to `examples/proxy_request.rb` on how to use these hostcalls.