### PR TITLE
Add --mapping cli option to include more than one source file

### DIFF
--- a/lib/compute_runtime/cli.rb
+++ b/lib/compute_runtime/cli.rb
@@ -13,8 +13,8 @@ module ComputeRuntime
     end
 
     def pack_directory(infile, outfile, dirmaps, dirmap_strings)
-      mapdir_args = dirmaps.collect_concat { |k, v| ["--mapdir", "#{k}::#{v}"] }
-      mapdir_args += dirmap_strings.collect_concat { |str| ["--mapdir", str] }
+      mapdir_args = dirmaps.collect_concat { |k, v| ["--dir", "#{v}::#{k}"] }
+      mapdir_args += dirmap_strings.collect_concat { |str| ["--dir", str] }
       pack_args = ["pack", infile, "-o", outfile] + mapdir_args
       run_rbwasm(*pack_args)
     end
@@ -67,7 +67,7 @@ module ComputeRuntime
       opts.on("-o", "--output FILE", "Output file") { |v| @output = v }
       opts.on("--[no-]stdlib", "Include stdlib in the output or not") { |v| @stdlib = v }
       opts.on("--remake", "Remake ruby.wasm") { |v| @remake = v }
-      opts.on("--mapping <HOST_DIR::GUEST_DIR>...", "Package a host directory into Wasm module at a guest directory") { |v| @mapping.push(v) }
+      opts.on("--dir <HOST_DIR::GUEST_DIR>...", "Package a host directory into Wasm module at a guest directory") { |v| @mapping.push(v) }
       opts.parse!
       @input = args.shift
       raise "No input file" unless @input

--- a/lib/compute_runtime/cli.rb
+++ b/lib/compute_runtime/cli.rb
@@ -39,6 +39,9 @@ module ComputeRuntime
       Dir.mktmpdir do |dir|
         # Copy input file to the directory
         FileUtils.cp(input_file, dir)
+        if @opts[:mapping]
+          @opts[:mapping].split(",").each {|f| FileUtils.cp_r(f,dir)}
+        end
 
         mapping = {
           "/exe" => dir,
@@ -65,6 +68,7 @@ module ComputeRuntime
       opts.on("-o", "--output FILE", "Output file") { |v| @output = v }
       opts.on("--[no-]stdlib", "Include stdlib in the output or not") { |v| @stdlib = v }
       opts.on("--remake", "Remake ruby.wasm") { |v| @remake = v }
+      opts.on("--mapping SOURCE", "Comma-separated app source file/folder names to be mapped (e.g. some_helper.rb,lib,public)") { |v| @mapping = v }
       opts.parse!
       @input = args.shift
       raise "No input file" unless @input
@@ -72,7 +76,7 @@ module ComputeRuntime
 
     def run(args)
       parse_args(args)
-      toolchain = Toolchain.new(stdlib: @stdlib, remake: @remake)
+      toolchain = Toolchain.new(stdlib: @stdlib, remake: @remake, mapping: @mapping)
       toolchain.compile(@input, @output)
     end
   end


### PR DESCRIPTION
This is a proposal to allow users to add more than one input source file. Please discard this if this doesn't match with the current plan or design - I can customize `cli.rb` locally for the time being (i.e. I needed to do so to make my blog app work).