### PR TITLE
fix: bypass LoadError at rack_helper.rb by default

### DIFF
--- a/lib/compute_runtime/rack_helper.rb
+++ b/lib/compute_runtime/rack_helper.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
-require "uri"
-require "rack"
+begin
+  require "uri"
+  require "rack"
+rescue LoadError => e
+  puts "Warning:"
+  puts "   Failed to load dependeincies. Details; #{e.message}"
+  puts "   Consider adding --stdlib upon compilation or make sure rack gem is installed properly"
+end
 
 module ComputeRuntime
   module RackHelper


### PR DESCRIPTION
I was testing the following setup step in the README.md and noticed now the sample.wasm compiled without --stdlib option doesn't work because of my previous commit (dependency to uri gem);
```
$ cd examples
$ bundle install
$ bundle exec ruby-compute-runtime demo.rb -o sample.wasm
```

The error I've got when receiving requests usingsample.wasm;
```
2024-04-21T13:45:03.737962Z  INFO Listening on http://127.0.0.1:7676
2024-04-21T13:45:06.563023Z  INFO request{id=0}: handling request GET http://localhost:7676/
/bundle/gems/compute_runtime-0.1.0/lib/compute_runtime/rack_helper.rb:3:in `require': cannot load such file -- uri (LoadError)
	from /bundle/gems/compute_runtime-0.1.0/lib/compute_runtime/rack_helper.rb:3:in `<top (required)>'
	from /bundle/gems/compute_runtime-0.1.0/lib/compute_runtime.rb:5:in `require_relative'
	from /bundle/gems/compute_runtime-0.1.0/lib/compute_runtime.rb:5:in `<top (required)>'
	from /exe/demo.rb:6:in `require'
	from /exe/demo.rb:6:in `<main>'
2024-04-21T13:45:06.609441Z ERROR request{id=0}: WebAssembly exited with error: error while executing at wasm backtrace:
    0: 0xaf2377 - <unknown>!__wasi_proc_exit
    1: 0xa2c64a - <unknown>!_start
```

This PR addresses this issue by bypassing LoadError at rack_helper.rb. Not sure if this is the best way to work around though, with this error handling at least user program doesn't need RackHelper can continue working without having --stdlib option upon compilation.