### PR TITLE
fix: change ref for ruby_wasm

### DIFF
--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 gem "compute_runtime", path: "../"
-gem "ruby_wasm", git: "https://github.com/ruby/ruby.wasm.git", ref: "9770bbed1c9ee3f32c713ad5882e1ee43dba9954"
+gem "ruby_wasm", git: "https://github.com/ruby/ruby.wasm.git", ref: "fa30a3eb665dc65c9e93ffc244324043e44781c4"
 gem "rack"
 
 # Optional: only needed for lobster.rb


### PR DESCRIPTION
Changing git ref to `fa30a3eb665dc65c9e93ffc244324043e44781c4` so that #13 is resolved by default.