### PR TITLE
fix: add uri gem as required dependency

### DIFF
--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "compute_runtime", path: "../"
 gem "ruby_wasm", git: "https://github.com/ruby/ruby.wasm.git", ref: "fa30a3eb665dc65c9e93ffc244324043e44781c4"
 gem "rack"
+gem "uri"
 
 # Optional: only needed for lobster.rb
 gem "rackup"


### PR DESCRIPTION
As rack_helper.rb is added with 6d04e7b39cbff4e97dcded958fa6f81acaa1b342 now uri gem is required to install (otherwise LoadError occurs)